### PR TITLE
Updated to actually add the CRIME attack as a rule too

### DIFF
--- a/lib/checks/compression.js
+++ b/lib/checks/compression.js
@@ -114,6 +114,22 @@ module.exports = exports = function(payload, options, fn) {
 
         });
 
+      // add the vunerable rule
+      payload.addRule({
+
+        type:           'critical',
+        key:            'crime',
+        message:        'Vulnerability to the CRIME attack was found'
+
+      }, {
+
+          display:      'code',
+          message:      '$ is vulnerable as TLS Compression is enabled',
+          code:         build,
+          identifiers:  [ address ]
+
+        });
+
     }
 
     // done !


### PR DESCRIPTION
This is implied by TLS compression but seeing it in the list as a critical prompts more users
