### PR TITLE
Updated to match the current framework of building test suites

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,23 @@
 const passmarked  = require('passmarked');
-const _           = require('lodash');
+const _           = require('underscore')
 
 /**
 * Creates the actual test
 **/
-var Test = require('passmarked').createTest(
+var Test = passmarked.createTest(
 
-  {},
-  require('./package.json'),
-  require('./worker.json'),
-  {
+  _.extend(
 
-    rules: require('./lib/rules')
+    {},
+    require('./package.json'),
+    require('./worker.json'),
+    {
 
-  }
+      rules: require('./lib/rules')
+
+    }
+
+  )
 
 );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passmarked/ssl",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Rules that relate to checking the SSL configuration of each individual resolved server from the domain to ensure locked down config with the broadest compatibility",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This will allow us to add methods like #bootstrap (as is being used here to load CA's into cache) and more methods like #onTimeout which will be making a appearance as we move forward to better control flow in the tests.

Bumping the version to 1.0.4 to get this out in the wild too
