### PR TITLE
Release 1.0.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,23 @@
 const passmarked  = require('passmarked');
-const _           = require('lodash');
+const _           = require('underscore')
 
 /**
 * Creates the actual test
 **/
-var Test = require('passmarked').createTest(
+var Test = passmarked.createTest(
 
-  {},
-  require('./package.json'),
-  require('./worker.json'),
-  {
+  _.extend(
 
-    rules: require('./lib/rules')
+    {},
+    require('./package.json'),
+    require('./worker.json'),
+    {
 
-  }
+      rules: require('./lib/rules')
+
+    }
+
+  )
 
 );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passmarked/ssl",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Rules that relate to checking the SSL configuration of each individual resolved server from the domain to ensure locked down config with the broadest compatibility",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Release 1.0.4 contains a few updates to future proof the test and fix a issue we had with slow CA certs. These are now correctly being loaded in as the test starts and then used from a in memory cache instead
