### PR TITLE
Removed the requirement for OSCP after quite a bit of research

### DIFF
--- a/lib/checks/status.js
+++ b/lib/checks/status.js
@@ -137,24 +137,6 @@ module.exports = exports = function(payload, options, fn) {
 
       }
 
-    } else {
-
-      // add the vunerable rule
-      payload.addRule({
-
-        type:         'notice',
-        key:          'ocsp',
-        message:      'OCSP stapling is not configured'
-
-      }, {
-
-        message:      'The server at $ did not report having OCSP enabled',
-        identifiers:  [ address ],
-        code:         build,
-        display:      'code'
-
-      });
-
     }
 
     // get the OCP status


### PR DESCRIPTION
Also saw that most sites don't need this configured at the moment. We'd rather correct and verify if enabled