### PR TITLE
Added the HTTPS/HTTP form check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ language: node_js
 env:
   - CXX=g++-4.8
 node_js:
-  - '6.2'
-  - '5.1'
-  - '4.2'
-  - '0.12'
+  - 'node'
+  - '8'
+  - '6'
+  - '5'
+  - '4'
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The rules checked in this module are:
 * **expire** - The certificate is shorter than a month away from expiring.
 * **expired** - The certificate presented by the server has expired and is not valid anymore
 * **freak** - The server has the **EXPORT** cipher enabled which leads to a vulnerability for the [FREAK](https://freakattack.com/) attack.
+* **form.internal** - An unsecurred internal form action from the HTTPS page will cause a browser to show a unsecure message
+* **form.external** - An unsecurred external form action from the HTTPS page will cause a browser to show a unsecure message
+* **field.creditcard** - The page will be shown as unsecure due to it not being over HTTPS but including a field identified as a credit card field
+* **field.password** - The page will be shown as unsecure due to it not being over HTTPS but including a password field
 * **heartbleed** - Vulnerability to the [HeartBleed](http://heartbleed.com/) attack was found
 * **host** - The certificate presented by the server did not have the host requested featured, leading to a hostname mismatch error.
 * **missing** - The server did not supply a certificate, this normally indicates that no certificate was configured although SSL is being offered.

--- a/docs/form.external.md
+++ b/docs/form.external.md
@@ -1,0 +1,23 @@
+HTTPS allows websites to secure their users by not allowing any man-in-the-middle attacks. This keeps users' data secure and ensures that no nefarious eyes can peek and steal user data.
+
+The page uses HTTPS which is great, your users are thankfull. But when there is a form on the page submits to a non-secured page (be it internal or external pages) browsers will change your "secure" page to "insecure" in the url bar. Firefox takes this a step further and shows a dialog warning users that they are submitting to a non-secured page in a dialog, where the user needs to click "continue" after a scary message.
+
+This happens because one of the forms on the page has it's `action=` set to a http:// page from a https:// page. 
+
+Look for something like the following:
+
+```
+<form method="POST" url="http://extenal.example.com/add">
+```
+
+# How do I fix this ?
+
+Ensure the target page for your form supportshttps as well. Then change the URL to the https version of the URL:
+
+```
+<form method="POST" url="https://extenal.example.com/add">
+```
+
+# Resources
+
+* [How do I disable the "Security Warning" - encrpted script message when I log in to a website using https ?](https://support.mozilla.org/en-US/questions/1012395)

--- a/docs/form.internal.md
+++ b/docs/form.internal.md
@@ -1,0 +1,23 @@
+HTTPS allows websites to secure their users by not allowing any man-in-the-middle attacks. This keeps users' data secure and ensures that no nefarious eyes can peek and steal user data.
+
+The page uses HTTPS which is great, your users are thankfull. But when there is a form on the page submits to a non-secured page (be it internal or external pages) browsers will change your "secure" page to "insecure" in the url bar. Firefox takes this a step further and shows a dialog warning users that they are submitting to a non-secured page in a dialog, where the user needs to click "continue" after a scary message.
+
+This happens because one of the forms on the page has it's `action=` set to a http:// page from a https:// page. 
+
+Look for something like the following:
+
+```
+<form method="POST" url="http://insecure.example.com/login">
+```
+
+# How do I fix this ?
+
+Ensure the target page for your form supportshttps as well. Then change the URL to the https version of the URL:
+
+```
+<form method="POST" url="https://secure.example.com/login">
+```
+
+# Resources
+
+* [How do I disable the "Security Warning" - encrpted script message when I log in to a website using https ?](https://support.mozilla.org/en-US/questions/1012395)

--- a/lib/rules/form.js
+++ b/lib/rules/form.js
@@ -1,0 +1,143 @@
+// pull in our modules
+const S               = require('string');
+const url             = require('url');
+const cheerio         = require('cheerio');
+
+/**
+* Checks if the any form submission on the page goes to http from https,
+* this will cause browsers to show a security alert to the user. 
+**/
+module.exports = exports = function(payload, fn) {
+
+  // get the data
+  var data = payload.getData();
+
+  // only if SSL
+  if(S( (data.url || '').toLowerCase() ).startsWith("https") == false) {
+
+    // debugging
+    payload.debug('fields', 'Skipping fields check as HTTPS is enabled for request');
+
+    // done
+    return fn(null);
+
+  }
+
+  // get the content
+  payload.getPageContent(function(err, content) {
+
+    // check for a error
+    if(err) {
+
+      // output the error
+      payload.error('fields', 'Problem getting the page content', err);
+
+      // done
+      return fn(err);
+
+    }
+
+    // check if the content is not empty
+    if(S(content || '').isEmpty() === true) {
+
+      // debug
+      payload.warning('fields', 'The content given was empty or blank');
+
+      // done
+      return fn(null);
+
+    }
+
+    // parse the url
+    var uri = url.parse(data.url);
+
+    // load the content
+    var $ = cheerio.load(content || '');
+
+    // get the lines of the file
+    var lines = content.split('\n');
+
+    // the last line for the code search
+    var lastLine = -1;
+
+    // loop the fields on the page
+    $('body form').each(function(index, elem) {
+
+      // get the type of the input
+      var formAction      = $(elem).attr('action') || '';
+
+      // ignore blank
+      if(S(formAction).isEmpty() === true || 
+          S(formAction).trim().s.indexOf('#') === 0 ||
+            S(formAction).trim().s.indexOf('javascript:void') === 0 ||
+              S(formAction).trim().s.indexOf('//') === 0 || 
+                S(formAction).trim().s.indexOf('/') === 0 || 
+                  S(formAction).trim().s.indexOf('https://') === 0) {
+
+        // all good, just skip
+        return;
+
+      }
+
+      // build a code snippet
+      var build = payload.getSnippetManager().build(lines, lastLine, function(line) {
+
+        return line.toLowerCase().indexOf('action="' + formAction.slice(0, 10)) !== -1;
+
+      });
+
+      // parse the link
+      var actionUri = url.parse(formAction);
+
+      // sanity check
+      if(!build) return;
+
+      // set the subject
+      lastLine = build.subject;
+
+      // build out the occurrence details
+      var occurrence = {
+
+        message:      '<form action="$"',
+        identifiers:  [ formAction ],
+        display:      'code',
+        code:         build
+
+      };
+
+      // check if local
+      var isLocal = S(actionUri.hostname || '').endsWith((uri.hostname || '').replace('www.', ''));
+
+      // is this local
+      if(isLocal == true) {
+
+        // yeap, this is quite bad ...
+        payload.addRule({
+
+          type:         'critical',
+          key:          'form.internal',
+          message:      'Form submissions to non-secure (http) pages will result in a security warning for users'
+
+        }, occurrence);
+
+      } else {
+
+        // note worthy
+        payload.addRule({
+
+          type:         'warning',
+          key:          'form.external',
+          message:      'Form submissions to external non-secure (http) pages will result in a security warning for users'
+
+        }, occurrence);
+
+      }
+
+    });
+
+    // done !
+    fn(null);
+
+  });
+
+};

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -3,6 +3,7 @@ module.exports = exports = [
   require('./enabled'),
   require('./client'),
   require('./fields'),
+  require('./form'),
   require('./clientside')
   
 ];

--- a/samples/form.ignored.html
+++ b/samples/form.ignored.html
@@ -1,0 +1,23 @@
+<html>
+  <body>
+    
+    <form action="" method="POST">
+    </form>
+    
+    <form action="#" method="POST">
+    </form>
+    
+    <form action="#anything" method="POST">
+    </form>
+    
+    <form action="/" method="POST">
+    </form>
+    
+    <form action="//example.com" method="POST">
+    </form>
+    
+    <form action="javascript:void(0);" method="POST">
+    </form>
+
+  </body>
+</html>

--- a/samples/form.insecure.html
+++ b/samples/form.insecure.html
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    
+    <form action="http://example.com" method="POST">
+    </form>
+
+  </body>
+</html>

--- a/samples/form.none.html
+++ b/samples/form.none.html
@@ -1,0 +1,3 @@
+<html>
+  <body></body>
+</html>

--- a/samples/form.secure.html
+++ b/samples/form.secure.html
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    
+    <form action="https://example.com" method="POST">
+    </form>
+
+  </body>
+</html>

--- a/test/form.js
+++ b/test/form.js
@@ -1,0 +1,169 @@
+const assert      = require('assert');
+const _           = require('underscore');
+const fs          = require('fs');
+const passmarked  = require('passmarked');
+const testFunc    = require('../lib/rules/form');
+
+describe('form', function() {
+
+  it('Should return a error for the external domain', function(done) {
+
+    // read in the html sample
+    var content = fs.readFileSync('./samples/form.insecure.html');
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      url: 'https://test.com'
+
+    }, { log: { entries: [] } }, content.toString())
+
+    testFunc(payload, function(err) {
+
+      if(err) assert.fail('Something went wrong');
+      var rules = payload.getRules();
+        var rule = _.find(rules || [], function(item) { 
+
+          return item.key === 'form.external'; 
+
+        });
+        if(!rule)
+          assert.fail('Was expecting a error');
+      // done
+      done()
+
+    });
+
+  });
+
+  it('Should return a error for the internal domain', function(done) {
+
+    // read in the html sample
+    var content = fs.readFileSync('./samples/form.insecure.html');
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      url: 'https://example.com'
+
+    }, { log: { entries: [] } }, content.toString())
+
+    testFunc(payload, function(err) {
+
+      if(err) assert.fail('Something went wrong');
+      var rules = payload.getRules();
+        var rule = _.find(rules || [], function(item) { 
+
+          return item.key === 'form.internal'; 
+
+        });
+        if(!rule)
+          assert.fail('Was expecting a error');
+      // done
+      done()
+
+    });
+
+  });
+
+  it('Should not return a error if the page is secure and the form is secure', function(done) {
+
+    // read in the html sample
+    var content = fs.readFileSync('./samples/form.secure.html');
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      url: 'https://example.com'
+
+    }, { log: { entries: [] } }, content.toString())
+
+    testFunc(payload, function(err) {
+
+      if(err) assert.fail('Something went wrong');
+      var rules = payload.getRules();
+      if(rules.length > 0) 
+        assert.fail('Was not expecting a error');
+      // done
+      done()
+
+    });
+
+  });
+
+  it('Should return a error if the page is secure and the form is unsecure', function(done) {
+
+    // read in the html sample
+    var content = fs.readFileSync('./samples/form.insecure.html');
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      url: 'https://example.com'
+
+    }, { log: { entries: [] } }, content.toString())
+
+    testFunc(payload, function(err) {
+
+      if(err) assert.fail('Something went wrong');
+      var rules = payload.getRules();
+      if(rules.length <= 0) 
+        assert.fail('Was expecting a error');
+      // done
+      done()
+
+    });
+
+  });
+
+  it('Should just skip if the page is over http://', function(done) {
+
+    // read in the html sample
+    var content = fs.readFileSync('./samples/form.secure.html');
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      url: 'http://example.com'
+
+    }, { log: { entries: [] } }, content.toString())
+
+    testFunc(payload, function(err) {
+
+      if(err) assert.fail('Something went wrong');
+      var rules = payload.getRules();
+      if(rules.length > 0) 
+        assert.fail('Was not expecting a error');
+      // done
+      done()
+
+    });
+
+  });
+
+  it('Should ignore if using special attributes like (#, /, //, javascript:void(0);, blank)', function(done) {
+
+    // read in the html sample
+    var content = fs.readFileSync('./samples/form.ignored.html');
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      url: 'http://example.com'
+
+    }, { log: { entries: [] } }, content.toString())
+
+    testFunc(payload, function(err) {
+
+      if(err) assert.fail('Something went wrong');
+      var rules = payload.getRules();
+      if(rules.length > 0) 
+        assert.fail('Was not expecting a error');
+      // done
+      done()
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Discovered sites that want to post from a secure page to a secure page now shows errors in browsers to users. This includes the rule "form.internal" and "form.external" that distinguishes occurrence based on if the form was referencing an internal page or an external page.